### PR TITLE
Fix omnicrossbow conflict

### DIFF
--- a/src/main/java/survivalblock/crossbow_scoping/common/CrossbowScoping.java
+++ b/src/main/java/survivalblock/crossbow_scoping/common/CrossbowScoping.java
@@ -5,6 +5,7 @@ import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.ChargedProjectilesComponent;
 import net.minecraft.entity.player.PlayerEntity;
@@ -23,7 +24,9 @@ public class CrossbowScoping implements ModInitializer {
 	public static final String MOD_ID = "crossbow_scoping";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-	@Override
+    public static final boolean OMNICROSSBOW_LOADED = FabricLoader.getInstance().isModLoaded("omnicrossbow");
+
+    @Override
 	public void onInitialize() {
 		CrossbowScopingDataComponentTypes.init();
 		CrossbowScopingGameRules.init();

--- a/src/main/java/survivalblock/crossbow_scoping/mixin/crossbow/LivingEntityMixin.java
+++ b/src/main/java/survivalblock/crossbow_scoping/mixin/crossbow/LivingEntityMixin.java
@@ -1,17 +1,24 @@
 package survivalblock.crossbow_scoping.mixin.crossbow;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.CrossbowItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SpyglassItem;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import survivalblock.crossbow_scoping.common.CrossbowScoping;
 import survivalblock.crossbow_scoping.common.init.CrossbowScopingDataComponentTypes;
 
 @Mixin(LivingEntity.class)
-public class LivingEntityMixin {
+public abstract class LivingEntityMixin extends Entity {
+
+    public LivingEntityMixin(EntityType<?> type, World world) {
+        super(type, world);
+    }
 
     @ModifyExpressionValue(method = {"tickActiveItemStack", "consumeItem"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;getStackInHand(Lnet/minecraft/util/Hand;)Lnet/minecraft/item/ItemStack;"))
     private ItemStack replaceWithScope(ItemStack original) {
@@ -19,6 +26,9 @@ public class LivingEntityMixin {
             return original;
         }
         if (!CrossbowScoping.isLoaded(original)) {
+            return original;
+        }
+        if (CrossbowScoping.OMNICROSSBOW_LOADED && isSneaking()) {
             return original;
         }
         ItemStack stackInComponents = original.getOrDefault(CrossbowScopingDataComponentTypes.CROSSBOW_SCOPE, ItemStack.EMPTY);

--- a/src/main/java/survivalblock/crossbow_scoping/mixin/crossbow/client/MinecraftClientMixin.java
+++ b/src/main/java/survivalblock/crossbow_scoping/mixin/crossbow/client/MinecraftClientMixin.java
@@ -12,7 +12,6 @@ import net.minecraft.client.option.GameOptions;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 import org.jetbrains.annotations.Nullable;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -45,7 +44,7 @@ public class MinecraftClientMixin {
         }
         Pair<ItemStack, Hand> pair = CrossbowScoping.getCrossbowWithScope(this.player);
         ItemStack stack = pair.getFirst();
-        if (stack.isEmpty() || !CrossbowScoping.isLoaded(stack)) {
+        if (stack.isEmpty() || !CrossbowScoping.isLoaded(stack) || this.player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
             original.call(instance, breaking);
             return;
         }


### PR DESCRIPTION
Fixes loading multiple shots with multichambered, and fixes being able to shoot while crossbows are on cooldown (does not add any cooldowns)

1. Do you want OMNICROSSBOW_LOADED to be stored somewhere else?
2. Currently, if omnicrossbow is installed then nothing can be shot while sneaking, regardless of if the crossbow has multichambered. This can be fixed by adding a dependency on omnicrossbow.

Let me know any changes you would like.
